### PR TITLE
Support from empty lines and comment lines

### DIFF
--- a/local/instructions.go
+++ b/local/instructions.go
@@ -137,6 +137,7 @@ func Set(val, address *Param) error {
 	return values.Write(reg, val.data)
 }
 func In(address *Param) error {
+	fmt.Print("Input: ")
 	reader := bufio.NewReader(os.Stdin)
 	text, err := reader.ReadString('\n')
 	if err != nil {

--- a/local/main.go
+++ b/local/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/jorgenhanssen/a-machine/local/logging"
 	"github.com/jorgenhanssen/a-machine/local/tape"
@@ -40,13 +41,20 @@ func main() {
 	ensure(err)
 
 	logger.LoadProgram(fileData)
-	program, err := extractInstructions(fileData)
+
+	compileStart := time.Now()
+
+	parser := NewParser()
+	program, err := parser.extractInstructions(fileData)
 	ensure(err)
 
 	// Insert instructions
 	for i, instruction := range program {
 		ensure(instructions.Write(i, instruction))
 	}
+
+	compileEnd := time.Now()
+	logger.Print(fmt.Sprintf("Compiled in %v", compileEnd.Sub(compileStart)))
 
 	// run program
 	for ; ; programCursor++ {

--- a/local/parsing.go
+++ b/local/parsing.go
@@ -9,7 +9,6 @@ import (
 )
 
 type Parser struct {
-	// offset         int
 	jumpsToResolve map[int]bool
 }
 

--- a/local/parsing.go
+++ b/local/parsing.go
@@ -1,13 +1,17 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
 )
+
+type Parser struct {
+	// offset         int
+	jumpsToResolve map[int]bool
+}
 
 type Param struct {
 	isReference bool
@@ -35,26 +39,61 @@ func ReadFile(filename string) (string, error) {
 	}
 }
 
-func extractInstructions(fileData string) (Instructions, error) {
+func NewParser() *Parser {
+	return &Parser{
+		jumpsToResolve: map[int]bool{},
+	}
+}
+
+func (p *Parser) extractInstructions(fileData string) (Instructions, error) {
 	lines := strings.Split(fileData, "\n")
 
 	var instructions Instructions
 	for i, line := range lines {
-		if instruction, err := parseInstruction(line); err != nil {
+		instruction, err := p.parseInstruction(line)
+		if err != nil {
 			return nil, fmt.Errorf("Error at line %d: %v", i+1, err)
-		} else {
+		}
+
+		if instruction != nil {
+			// Instruction may be nil if line is a comment or empty line
 			instructions = append(instructions, instruction)
+		}
+	}
+
+	// resolve jumps
+	lineToInstructionIndex := map[int]int{} // code line => instruction index
+	offset := 0
+	for i, line := range lines {
+		if lineIsNonFunctional(line) {
+			offset++
+			continue
+		}
+
+		lineNumber := i + 1
+		if p.jumpsToResolve[lineNumber] {
+			lineToInstructionIndex[lineNumber] = lineNumber - offset
+		}
+	}
+
+	// adjust jump addresses from code line to instruction index
+	for _, in := range instructions {
+		if isOneOf(in.command, iJumpGreaterThan, iJumpEqual, iJumpLessThan) {
+			in.params[2].data = lineToInstructionIndex[in.params[2].data]
+		} else if isOneOf(in.command, iJump) {
+			in.params[0].data = lineToInstructionIndex[in.params[0].data]
 		}
 	}
 
 	return instructions, nil
 }
 
-func parseInstruction(iLine string) (*Instruction, error) {
-	stringData := strings.Split(iLine, " ")
-	if stringData[0] == "" {
-		return nil, errors.New("empty line not allowed.")
+func (p *Parser) parseInstruction(iLine string) (*Instruction, error) {
+	if lineIsNonFunctional(iLine) {
+		return nil, nil
 	}
+
+	stringData := strings.Split(iLine, " ")
 
 	iID := iMap[strings.ToUpper(stringData[0])]
 	if iID == 0 {
@@ -93,10 +132,27 @@ func parseInstruction(iLine string) (*Instruction, error) {
 		})
 	}
 
+	// if instruction is a jump, we need to adjust the address for
+	// empty lines and single-line comments
+	if isOneOf(iID, iJumpGreaterThan, iJumpEqual, iJumpLessThan) {
+		p.jumpsToResolve[params[2].data] = true
+	} else if isOneOf(iID, iJump) {
+		p.jumpsToResolve[params[0].data] = true
+	}
+
 	return &Instruction{
 		command: iID,
 		params:  params,
 	}, nil
+}
+
+func isOneOf(value int, values ...int) bool {
+	for _, v := range values {
+		if value == v {
+			return true
+		}
+	}
+	return false
 }
 
 func safeInterfaceToInt(value interface{}) (int, error) {
@@ -130,4 +186,9 @@ func safeReadAddress(address *Param) (int, error) {
 		}
 	}
 	return reg, nil
+}
+
+// if empty or comment (starts with //), return true
+func lineIsNonFunctional(line string) bool {
+	return strings.TrimSpace(line) == "" || strings.HasPrefix(line, "//")
 }

--- a/programs/count
+++ b/programs/count
@@ -1,6 +1,14 @@
-set '0' 1   // val in reg 1 will be incremented (starts at 0)
-set '1' 2   // it will be incremented by reg 2 which is set to a value of 1
-in 3        // user inputs a number into reg 3
-add 1 2 1   // adds 1 (reg 2) to reg 1
-out 1       // write the current value
-jlt 1 3 4   // if less than target then jump to line 4 to add again
+// A simple program that counts from 0 to a user-inputted number
+
+// Set variables
+set '0' 1   // current value (will be incremented)
+set '1' 2   // how much to increment by (1)
+
+// User inputs a number to count to (reg 3)
+in 3
+
+// Loop and print the current value
+// Until the current value is equal to the target
+add 1 2 1    // adds reg 2 to reg 1
+out 1        // print the current value
+jlt 1 3 12   // Go back to line 12 if less than user's input

--- a/programs/prime
+++ b/programs/prime
@@ -1,15 +1,29 @@
-in 1            // input number from user into reg 1
+// A simple program to check if a number is prime
+// outputs 1 if prime, 0 if not
+
+// User inputs a number to check (reg 1)
+in 1
+
+// Set variables
 set '1' 2       // reg 2 holds if the number is prime, we assume it is so we put 1 
 set '3' 3       // iterator start-value stored in reg 3
 set '2' 4       // iterator increment value stored in reg 4
-div 1 4 5       // iterator max condition stored in reg 5 (num/2)
+div 1 4 5       // max iterator value (num/2)
+
 mod 1 4 6       // the modulo of the input number and iterator value is stored in 6. We start to check if the number is divisible by 2
 set '0' 7       // used as reference for modulo. If a module is 0 (which is stored here), then a number is not prime
-jeq 6 7 14      // if the input number is divisible by the current iterator value then jump to 14
+
+// Loop and check if the number is prime
+jeq 6 7 26      // if the input number is divisible by the current iterator value then jump to 14
 mod 1 3 6       // insert the modulo of the input number vs iterator number in 6.
-jeq 6 7 14      // if the input number is divisible by the current iterator value then jump to 14
+jeq 6 7 26      // if the input number is divisible by the current iterator value then jump to 14
 add 3 4 3       // increment the iterator value by the iterator increment value.
-jlt 3 5 9       // if the iterator has not reached the max iterator value, jump to 8
-jmp 15          // jump to 15
-set '0' 2       // We get here if a number is not prime, set the 'isPrime' identifier to 0
-out 2           // print if the number is prime
+jlt 3 5 17      // if the iterator has not reached the max iterator value, jump to start
+
+jmp 29 // The number is prime, jump to print
+
+// Jump here if the number is NOT prime
+set '0' 2
+
+// Output the result
+out 2


### PR DESCRIPTION
Programs can now be written with empty lines or comment lines like this:
```
1. // Set 1 into reg 0
2. set '1' 0
3.
4. // Print register 0
5. out 0
```

Instead of:

```
1. set '1' 0 // comment cannot be written by themselves
2. out 0     // there cannot be space between instructions
```

**Jumps will follow the line number, regardless of spaces between instructions.**