### PR TITLE
feat: initial syscall functionality (with macos x86_64 support)

### DIFF
--- a/programs/syscall
+++ b/programs/syscall
@@ -6,10 +6,14 @@
 // This is a syscall example for Mac x86_64
 // ref: https://opensource.apple.com/source/xnu/xnu-1504.3.12/bsd/kern/syscalls.master
 
-
 // Get PID into register 0
 sys 0 '20'
 out 0
 
-// Exit with code 42
-sys 0 '1' '42'
+// Modulo the PID by 10
+mod 0 '10' 0
+
+// Exit with the result as the exit code
+sys 0 '1' 0
+
+// Run 'echo $?' to see the exit code after running this program

--- a/programs/syscall
+++ b/programs/syscall
@@ -1,0 +1,9 @@
+// Syscall example for Mac x86_64
+// ref: https://opensource.apple.com/source/xnu/xnu-1504.3.12/bsd/kern/syscalls.master
+
+// Get PID into register 0
+sys 0 '20'
+out 0
+
+// Exit with code 42
+sys 0 '1' '42'

--- a/programs/syscall
+++ b/programs/syscall
@@ -1,5 +1,11 @@
-// Syscall example for Mac x86_64
+// Syscalls has the following signature:
+// sys <destination> <syscall_number> <arg1> <arg2> <arg3> <arg4> <arg5> <arg6>
+// the returned value from the syscall is stored in the destination register
+// Note that syscalls are platform-specific, so the syscall number for the target platform must be used.
+
+// This is a syscall example for Mac x86_64
 // ref: https://opensource.apple.com/source/xnu/xnu-1504.3.12/bsd/kern/syscalls.master
+
 
 // Get PID into register 0
 sys 0 '20'

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -63,4 +63,16 @@ pub enum Instruction {
 
     // destination
     Time(Param),
+
+    // https://syscalls64.paolostivanin.com/
+    Syscall(
+        Param,         // return destination
+        Param,         // syscall number
+        Option<Param>, // argument 1
+        Option<Param>, // argument 2
+        Option<Param>, // argument 3
+        Option<Param>, // argument 4
+        Option<Param>, // argument 5
+        Option<Param>, // argument 6
+    ),
 }

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -64,7 +64,6 @@ pub enum Instruction {
     // destination
     Time(Param),
 
-    // https://syscalls64.paolostivanin.com/
     Syscall(
         Param,         // return destination
         Param,         // syscall number

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod cli;
 mod instructions;
 mod parser;
 mod runner;
+mod syscall;
 
 use clap::Parser;
 use cli::CLI;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -131,6 +131,16 @@ impl Parser {
             "CALL" => Instruction::Call(self.parse_label(chunks[1])?),
             "RET" => Instruction::Return,
             "TIME" => Instruction::Time(self.parse_param(chunks[1])?),
+            "SYS" => Instruction::Syscall(
+                self.parse_param(chunks[1])?,
+                self.parse_param(chunks[2])?,
+                self.parse_optional_param(chunks.get(3))?,
+                self.parse_optional_param(chunks.get(4))?,
+                self.parse_optional_param(chunks.get(5))?,
+                self.parse_optional_param(chunks.get(6))?,
+                self.parse_optional_param(chunks.get(7))?,
+                self.parse_optional_param(chunks.get(8))?,
+            ),
             _ => {
                 return Err(ParseError::new(
                     &format!("Unknown instruction: {}", instruction_id),
@@ -140,6 +150,20 @@ impl Parser {
         };
 
         Ok(i)
+    }
+
+    fn parse_optional_param(&self, chunk: Option<&&str>) -> Result<Option<Param>, ParseError> {
+        match chunk {
+            None => Ok(None),
+            Some(chunk) => {
+                if *chunk == "_" {
+                    return Ok(None);
+                }
+
+                let param = self.parse_param(chunk)?;
+                Ok(Some(param))
+            }
+        }
     }
 
     fn parse_param(&self, chunk: &str) -> Result<Param, ParseError> {

--- a/src/syscall/macos_x86_64.rs
+++ b/src/syscall/macos_x86_64.rs
@@ -1,0 +1,129 @@
+use core::arch::asm;
+
+// Syscalls for macos x86_64 can be found here:
+// https://opensource.apple.com/source/xnu/xnu-1504.3.12/bsd/kern/syscalls.master
+
+// macos x86_64 syscalls have an offset of 0x2000000 (2 << 24)
+// https://modexp.wordpress.com/2017/01/21/shellcode-osx/
+// https://opensource.apple.com/source/xnu/xnu-792.13.8/osfmk/mach/i386/syscall_sw.h
+const SYSCALL_SHIFT: usize = 0x2000000;
+
+pub unsafe fn syscall0(n: usize) -> usize {
+    let mut ret: usize;
+    asm!(
+        "syscall",
+        inlateout("rax") n + SYSCALL_SHIFT => ret,
+        out("rcx") _, // rcx is used to store old rip
+        out("r11") _, // r11 is used to store old rflags
+        options(nostack, preserves_flags)
+    );
+    ret
+}
+
+pub unsafe fn syscall1(n: usize, arg1: usize) -> usize {
+    let mut ret: usize;
+    asm!(
+        "syscall",
+        inlateout("rax") n + SYSCALL_SHIFT => ret,
+        in("rdi") arg1,
+        out("rcx") _, // rcx is used to store old rip
+        out("r11") _, // r11 is used to store old rflags
+        options(nostack, preserves_flags)
+    );
+    ret
+}
+
+pub unsafe fn syscall2(n: usize, arg1: usize, arg2: usize) -> usize {
+    let mut ret: usize;
+    asm!(
+        "syscall",
+        inlateout("rax") n + SYSCALL_SHIFT => ret,
+        in("rdi") arg1,
+        in("rsi") arg2,
+        out("rcx") _, // rcx is used to store old rip
+        out("r11") _, // r11 is used to store old rflags
+        options(nostack, preserves_flags)
+    );
+    ret
+}
+
+pub unsafe fn syscall3(n: usize, arg1: usize, arg2: usize, arg3: usize) -> usize {
+    let mut ret: usize;
+    asm!(
+        "syscall",
+        inlateout("rax") n + SYSCALL_SHIFT => ret,
+        in("rdi") arg1,
+        in("rsi") arg2,
+        in("rdx") arg3,
+        out("rcx") _, // rcx is used to store old rip
+        out("r11") _, // r11 is used to store old rflags
+        options(nostack, preserves_flags)
+    );
+    ret
+}
+
+pub unsafe fn syscall4(n: usize, arg1: usize, arg2: usize, arg3: usize, arg4: usize) -> usize {
+    let mut ret: usize;
+    asm!(
+        "syscall",
+        inlateout("rax") n + SYSCALL_SHIFT => ret,
+        in("rdi") arg1,
+        in("rsi") arg2,
+        in("rdx") arg3,
+        in("r10") arg4,
+        out("rcx") _, // rcx is used to store old rip
+        out("r11") _, // r11 is used to store old rflags
+        options(nostack, preserves_flags)
+    );
+    ret
+}
+
+pub unsafe fn syscall5(
+    n: usize,
+    arg1: usize,
+    arg2: usize,
+    arg3: usize,
+    arg4: usize,
+    arg5: usize,
+) -> usize {
+    let mut ret: usize;
+    asm!(
+        "syscall",
+        inlateout("rax") n + SYSCALL_SHIFT => ret,
+        in("rdi") arg1,
+        in("rsi") arg2,
+        in("rdx") arg3,
+        in("r10") arg4,
+        in("r8")  arg5,
+        out("rcx") _, // rcx is used to store old rip
+        out("r11") _, // r11 is used to store old rflags
+        options(nostack, preserves_flags)
+    );
+    ret
+}
+
+pub unsafe fn syscall6(
+    n: usize,
+    arg1: usize,
+    arg2: usize,
+    arg3: usize,
+    arg4: usize,
+    arg5: usize,
+    arg6: usize,
+) -> usize {
+    let mut ret: usize;
+    asm!(
+        "syscall",
+        inlateout("rax") n + SYSCALL_SHIFT => ret,
+        in("rdi") arg1,
+        in("rsi") arg2,
+        in("rdx") arg3,
+        in("r10") arg4,
+        in("r8")  arg5,
+        in("r9")  arg6,
+        out("rcx") _, // rcx is used to store old rip
+        out("r11") _, // r11 is used to store old rflags
+        options(nostack, preserves_flags)
+    );
+    ret
+}

--- a/src/syscall/mod.rs
+++ b/src/syscall/mod.rs
@@ -1,0 +1,9 @@
+// Expose the syscall function out of the module.
+mod syscall;
+pub use syscall::syscall;
+
+// Support for macos x86_64
+#[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+mod macos_x86_64;
+#[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+use macos_x86_64::*;

--- a/src/syscall/syscall.rs
+++ b/src/syscall/syscall.rs
@@ -1,0 +1,29 @@
+use super::{syscall0, syscall1, syscall2, syscall3, syscall4, syscall5, syscall6};
+
+type Arg = Option<usize>;
+
+pub unsafe fn syscall(n: usize, a1: Arg, a2: Arg, a3: Arg, a4: Arg, a5: Arg, a6: Arg) -> usize {
+    match (a1, a2, a3, a4, a5, a6) {
+        (Some(a1), Some(a2), Some(a3), Some(a4), Some(a5), Some(a6)) => {
+            return syscall6(n, a1, a2, a3, a4, a5, a6);
+        }
+        (Some(a1), Some(a2), Some(a3), Some(a4), Some(a5), _) => {
+            return syscall5(n, a1, a2, a3, a4, a5);
+        }
+        (Some(a1), Some(a2), Some(a3), Some(a4), _, _) => {
+            return syscall4(n, a1, a2, a3, a4);
+        }
+        (Some(a1), Some(a2), Some(a3), _, _, _) => {
+            return syscall3(n, a1, a2, a3);
+        }
+        (Some(a1), Some(a2), _, _, _, _) => {
+            return syscall2(n, a1, a2);
+        }
+        (Some(a1), _, _, _, _, _) => {
+            return syscall1(n, a1);
+        }
+        (_, _, _, _, _, _) => {
+            return syscall0(n);
+        }
+    }
+}


### PR DESCRIPTION
Added the foundation for syscalls in YAUL.

This PR implements syscalls for the macos x86_64 arch, but can be extended to others as well.

Command signature is:
```
sys <destination> <syscall_number> <arg1> <arg2> <arg3> <arg4> <arg5> <arg6>
```

where the destination is the register where the value returned from the syscall is stored.