### PR TITLE
chore: deprecate terminate instruction

### DIFF
--- a/programs/binarysearch
+++ b/programs/binarysearch
@@ -24,7 +24,7 @@ add 1 10 1  // more than
 jmp LOOP    // jump back to line 6
 
 TERMINATE:
-term        // finish
+ret         // finish
 
 B:
 set '1' 10

--- a/programs/call
+++ b/programs/call
@@ -16,7 +16,7 @@ out 0
 out 1
 
 // End the program
-term
+ret
 
 // A function that squares the value at the address in register 100
 SQUARE:

--- a/programs/collatz
+++ b/programs/collatz
@@ -22,4 +22,4 @@ div 0 '2' 0
 jmp LOOP
 
 DONE:
-term
+ret

--- a/programs/sort
+++ b/programs/sort
@@ -19,7 +19,7 @@ set '10' 50
 call PRINT_ARRAY
 call SORT_ARRAY
 call PRINT_ARRAY
-term
+ret
 
 // Function that sorts the array
 SORT_ARRAY:

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -13,7 +13,6 @@ pub enum Instruction {
     JumpEqual(Source, Source, Label),
     JumpLessThan(Source, Source, Label),
     Move(Source, Destination),
-    Terminate,
     Call(Label),
     Return,
     Time(Destination),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -133,7 +133,6 @@ impl Parser {
                 self.parse_source(chunks[1])?,
                 self.parse_destination(chunks[2])?,
             ),
-            "TERM" => Instruction::Terminate,
             "CALL" => Instruction::Call(self.parse_label(chunks[1])?),
             "RET" => Instruction::Return,
             "TIME" => Instruction::Time(self.parse_destination(chunks[1])?),

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -148,6 +148,11 @@ impl Runner {
                     continue;
                 }
                 Instruction::Return => {
+                    if self.stack.is_empty() {
+                        // Returning from main works as program exit.
+                        return;
+                    }
+
                     pc = self.stack.pop().unwrap();
                     continue;
                 }
@@ -192,7 +197,6 @@ impl Runner {
                         self.registers[_destination as usize] = ret as i64;
                     }
                 }
-                Instruction::Terminate => return,
             }
 
             pc += 1;


### PR DESCRIPTION
Removed `term` instruction in favor of allow `ret` to exit the program if outside of any function context (main).