### PR TITLE
chore: deprecated mov in favor of set

### DIFF
--- a/programs/array
+++ b/programs/array
@@ -1,6 +1,6 @@
 set '0' 1       // REG1: index value
 set '100' 2     // REG2: offset value (to avoid overwriting registers)
-mov 2 3         // REG3: incremented/mutating offset value
+set 2 3         // REG3: incremented/mutating offset value
 set '1' 4       // REG4: iterator increment value
 in 5            // REG5: user inputs array length
 

--- a/programs/binarysearch
+++ b/programs/binarysearch
@@ -5,7 +5,7 @@ set '0' 3
 in 10           // REG10: user inputs array size => used as increment
 in 20           // REG20: user inputs index to find
 div 10 2 10     // REG10: current position increment
-mov 10 1        // REG1: position
+set 10 1        // REG1: position
 
 LOOP:
 div 10 2 10        // divide for next

--- a/programs/fibonacci
+++ b/programs/fibonacci
@@ -21,7 +21,7 @@ sub 0 6 0 // n = n - 2
 LOOP:
 add 1 2 3     // temp = prev + curr
 out 3         // print temp
-mov 2 1       // prev = curr
-mov 3 2       // curr = temp
+set 2 1       // prev = curr
+set 3 2       // curr = temp
 add 5 4 4     // increment loop counter
 jlt 4 0 LOOP  // if loop counter < n, re-loop

--- a/programs/sort
+++ b/programs/sort
@@ -35,8 +35,8 @@ jgt &11 &12 SORT_ARRAY_SWAP
 jmp SORT_ARRAY_LOOP_INNER_END
 
 SORT_ARRAY_SWAP:
-mov 11 100
-mov 12 101
+set 11 100
+set 12 101
 call SWAP
 
 SORT_ARRAY_LOOP_INNER_END:
@@ -60,9 +60,9 @@ ret
 // - 101: second variable to swap
 // - 102: internal use
 SWAP:
-mov &100 102
-mov &101 &100
-mov 102 &101
+set &100 102
+set &101 &100
+set 102 &101
 ret
 
 // Function that prints the array

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -1,5 +1,6 @@
 #[derive(Debug)]
 pub enum Instruction {
+    Return,
     Set(Source, Destination),
     Input(Destination),
     Output(Source),
@@ -12,9 +13,7 @@ pub enum Instruction {
     JumpGreaterThan(Source, Source, Label),
     JumpEqual(Source, Source, Label),
     JumpLessThan(Source, Source, Label),
-    Move(Source, Destination),
     Call(Label),
-    Return,
     Time(Destination),
     Syscall(
         Destination,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -82,6 +82,7 @@ impl Parser {
 
         // Use a match expression for direct mapping
         let i = match instruction_id.as_str() {
+            "RET" => Instruction::Return,
             "SET" => Instruction::Set(
                 self.parse_source(chunks[1])?,
                 self.parse_destination(chunks[2])?,
@@ -129,12 +130,7 @@ impl Parser {
                 self.parse_source(chunks[2])?,
                 self.parse_label(chunks[3])?,
             ),
-            "MOV" => Instruction::Move(
-                self.parse_source(chunks[1])?,
-                self.parse_destination(chunks[2])?,
-            ),
             "CALL" => Instruction::Call(self.parse_label(chunks[1])?),
-            "RET" => Instruction::Return,
             "TIME" => Instruction::Time(self.parse_destination(chunks[1])?),
             "SYS" => Instruction::Syscall(
                 self.parse_destination(chunks[1])?,

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -28,6 +28,15 @@ impl Runner {
             let instruction = &self.instructions[pc];
 
             match instruction {
+                Instruction::Return => {
+                    if self.stack.is_empty() {
+                        // Returning from main works as program exit.
+                        return;
+                    }
+
+                    pc = self.stack.pop().unwrap();
+                    continue;
+                }
                 Instruction::Set(value, destination) => {
                     let _value = self.read_source(value);
                     let _destination = self.read_destination(destination);
@@ -131,12 +140,6 @@ impl Runner {
                         continue;
                     }
                 }
-                Instruction::Move(source, destination) => {
-                    let _source = self.read_source(source);
-                    let _destination = self.read_destination(destination);
-
-                    self.registers[_destination] = _source;
-                }
                 Instruction::Call(label) => {
                     let _label = match label {
                         Label::Label(_) => panic!("Invalid label"),
@@ -145,15 +148,6 @@ impl Runner {
 
                     self.stack.push(pc + 1);
                     pc = _label;
-                    continue;
-                }
-                Instruction::Return => {
-                    if self.stack.is_empty() {
-                        // Returning from main works as program exit.
-                        return;
-                    }
-
-                    pc = self.stack.pop().unwrap();
                     continue;
                 }
                 Instruction::Time(destination) => {


### PR DESCRIPTION
They do the same, and while `mov` is more common in assembly, I find `set` to be a more descriptive instruction name since we can set both literals and registers.